### PR TITLE
Deploy Fake NFT

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+RPC_URL=xxx
+PRIVATE_KEY=xxx
+SCAN_API_KEY=xxx

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ out/
 !/broadcast
 /broadcast/*
 /broadcast/*/31337/
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
-# Development
+# Deploy Contract
 
-This repository uses the Foundry smart contract toolkit. You can download the Foundry installer by running `curl -L https://foundry.paradigm.xyz | bash`, and then install the latest version by running `foundryup` on a new terminal window (additional instructions are available on the [Foundry repo](https://github.com/foundry-rs/foundry#installation)).
+- Make sure .env is set properly
+
+### For mumbai test net(80001)
+
+```
+$ source .env
+$ forge script script/FakeNFT.s.sol:FakeNFTScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvvv
+```
+
+Contract Address: 0xc9991a0904206da66891156e83170fef61a27c19
+
+# Verify
+
+### For mumbai test net(80001)
+
+```
+$ forge verify-contract --chain 80001 {ContractAddress} src/FakeNFT.sol:FakeNFT $SCAN_API_KEY
+```

--- a/script/FakeNFT.s.sol
+++ b/script/FakeNFT.s.sol
@@ -2,11 +2,14 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
+import "../src/FakeNFT.sol";
 
-contract ContractScript is Script {
+contract FakeNFTScript is Script {
     function setUp() public {}
 
     function run() public {
         vm.broadcast();
+        new FakeNFT();
+        vm.stopBroadcast();
     }
 }

--- a/src/FakeNFT.sol
+++ b/src/FakeNFT.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./interfaces/INoxxABT.sol";
+
+/// @title NFT Contract that mimics NoxxABT except non-transferable
+contract FakeNFT is INoxxABT, ERC721URIStorage, Pausable, AccessControl {
+    using Counters for Counters.Counter;
+    Counters.Counter private supplyCounter;
+    bytes32 public constant MINT_ROLE = keccak256("MINT_ROLE");
+
+    constructor() ERC721("fake", "FTKN") {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(MINT_ROLE, msg.sender);
+    }
+
+    function mint(address to, string memory _tokenURI)
+        external
+        whenNotPaused
+        onlyRole(MINT_ROLE)
+    {
+        _mint(to, totalSupply());
+
+        _setTokenURI(totalSupply(), _tokenURI);
+
+        supplyCounter.increment();
+    }
+
+    function updateTokenURI(uint256 _tokenId, string memory _tokenURI)
+        external
+        onlyRole(MINT_ROLE)
+    {
+        _setTokenURI(_tokenId, _tokenURI);
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return supplyCounter.current();
+    }
+
+    /// @dev Pausing/resuming only allowed for admin
+    function pause() public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    /// @dev Pausing/resuming only allowed for admin
+    function unpause() public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    /// @dev See ERC4973 Contract
+    function burn(uint256 _tokenId) public {
+        require(msg.sender == ownerOf(_tokenId), "burn: sender must be owner");
+        _burn(_tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721, AccessControl)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/src/NoxxABT.sol
+++ b/src/NoxxABT.sol
@@ -9,8 +9,8 @@ import "./ERC4973.sol";
 import "./ERC4973URIStorage.sol";
 import "./interfaces/INoxxABT.sol";
 
-// NoxxABT is Account bound Token
-// - Token can be minted only once per address. Properties are updated through tokenURI
+/// @title NoxxABT is Account bound Token
+/// @dev Token can be minted only once per address. Properties are updated through tokenURI
 contract NoxxABT is
     INoxxABT,
     ERC4973,
@@ -28,7 +28,7 @@ contract NoxxABT is
         _grantRole(MINT_ROLE, msg.sender);
     }
 
-    /// @dev See {INoxxERC721-mint}.
+    /// @dev See {INoxxABT-mint}.
     function mint(address to, string memory _tokenURI)
         external
         whenNotPaused
@@ -42,7 +42,7 @@ contract NoxxABT is
         supplyCounter.increment();
     }
 
-    /// @dev See {INoxxERC721-updateTokenURI}
+    /// @dev See {INoxxABT-updateTokenURI}
     function updateTokenURI(uint256 tokenId, string memory _tokenURI)
         external
         onlyRole(MINT_ROLE)

--- a/src/test/FakeNFT.t.sol
+++ b/src/test/FakeNFT.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../FakeNFT.sol";
+
+contract FakeNFTTest is Test {
+    FakeNFT internal fktn;
+
+    function setUp() public {
+        fktn = new FakeNFT();
+    }
+
+    function testInit() public {
+        assertEq(fktn.name(), "fake");
+        assertEq(fktn.symbol(), "FTKN");
+        assertTrue(fktn.hasRole(fktn.MINT_ROLE(), address(this)));
+        assertTrue(fktn.hasRole(fktn.DEFAULT_ADMIN_ROLE(), address(this)));
+    }
+
+    function testCanMint() public {
+        fktn.mint(address(1), "https://test/0");
+        assertEq(fktn.balanceOf(address(1)), 1);
+    }
+
+    function testCannotMintUnAuthorized() public {
+        vm.prank(address(1));
+        vm.expectRevert(
+            "AccessControl: account 0x0000000000000000000000000000000000000001 is missing role 0x154c00819833dac601ee5ddded6fda79d9d8b506b911b3dbd54cdb95fe6c3686"
+        );
+        fktn.mint(address(2), "https://test/2");
+    }
+
+    function testCanUpdateTokenURI() public {
+        fktn.mint(address(1), "https://test/0");
+        assertEq(fktn.tokenURI(0), "https://test/0");
+
+        fktn.updateTokenURI(0, "https://test/1");
+        assertEq(fktn.tokenURI(0), "https://test/1");
+    }
+
+    function testCanBurnTokenByOwner() public {
+        fktn.mint(address(1), "https://test/0");
+        assertEq(fktn.tokenURI(0), "https://test/0");
+        // switch to token owner
+        vm.prank(address(1));
+        fktn.burn(0);
+        assertEq(fktn.balanceOf(address(1)), 0);
+        vm.expectRevert("ERC721: invalid token ID");
+        fktn.tokenURI(0);
+    }
+
+    function testCannotBurnTokenByNonOwnwer() public {
+        fktn.mint(address(1), "https://test/0");
+        assertEq(fktn.tokenURI(0), "https://test/0");
+        vm.expectRevert("burn: sender must be owner");
+        fktn.burn(0);
+    }
+
+    function testCanPauseMint() public {
+        fktn.pause();
+        vm.expectRevert("Pausable: paused");
+        fktn.mint(address(1), "https://test/0");
+
+        fktn.unpause();
+        fktn.mint(address(1), "https://test/0");
+    }
+
+    function testCanGrantRole() public {
+        fktn.grantRole(fktn.MINT_ROLE(), address(100));
+        vm.prank(address(100));
+        fktn.mint(address(1), "https://test/0");
+    }
+}


### PR DESCRIPTION
- ABT can only mint once. It's hard to test.
- We'll use fake NFT that mimics ABT. Everything is the same except we can mint/transfer
- Deployed to Polygon testnetwork(Mumbai 80001)

Execution log

```
 ~/workspace/knot/noxx-contract/ [main*] source .env
 ~/workspace/knot/noxx-contract/ [main*] echo $RPC_URL
https://polygon-mumbai.g.alchemy.com/v2/I6gHn7BidG6lV0NTXyX4Ehj2bsDXh_dX
 ~/workspace/knot/noxx-contract/ [main*] forge script script/FakeNFT.s.sol:FakeNFTScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvvv
[⠔] Compiling...
[⠒] Compiling 1 files with 0.8.13
[⠢] Solc 0.8.13 finished in 1.54s
Compiler run successful
Traces:
  [1758043] FakeNFTScript::run() 
    ├─ [0] VM::broadcast() 
    │   └─ ← ()
    ├─ [1720780] → new FakeNFT@"0xc999…7c19"
    │   ├─ emit RoleGranted(role: 0x0000000000000000000000000000000000000000000000000000000000000000, account: 0x69d49390a5748454f28611ebc90d0f5a2d679556, sender: 0x69d49390a5748454f28611ebc90d0f5a2d679556)
    │   ├─ emit RoleGranted(role: 0x154c00819833dac601ee5ddded6fda79d9d8b506b911b3dbd54cdb95fe6c3686, account: 0x69d49390a5748454f28611ebc90d0f5a2d679556, sender: 0x69d49390a5748454f28611ebc90d0f5a2d679556)
    │   └─ ← 8113 bytes of code
    ├─ [0] VM::stopBroadcast() 
    │   └─ ← ()
    └─ ← ()


Script ran successfully.
==========================
Simulated On-chain Traces:

  [1910400] → new FakeNFT@"0xc999…7c19"
    ├─ emit RoleGranted(role: 0x0000000000000000000000000000000000000000000000000000000000000000, account: 0x69d49390a5748454f28611ebc90d0f5a2d679556, sender: 0x69d49390a5748454f28611ebc90d0f5a2d679556)
    ├─ emit RoleGranted(role: 0x154c00819833dac601ee5ddded6fda79d9d8b506b911b3dbd54cdb95fe6c3686, account: 0x69d49390a5748454f28611ebc90d0f5a2d679556, sender: 0x69d49390a5748454f28611ebc90d0f5a2d679556)
    └─ ← 8113 bytes of code


==========================

Estimated total gas used for script: 2483520

Estimated amount required: 0.00745056003476928 ETH

==========================

###
Finding wallets for all the necessary addresses...
##
Sending transactions [0 - 0].
⠁ [00:00:00] [#############################################################################################################################################################################################] 1/1 txes (0.0s)
Transactions saved to: broadcast/FakeNFT.s.sol/80001/run-latest.json

##
Waiting for receipts.
⠉ [00:17:28] [#########################################################################################################################################################################################] 1/1 receipts (0.0s)
#####
✅ Hash: 0x5ee030e8aab0f33975b9033c139d2bdf09883f1f699632b29052f10d070239fe
Contract Address: 0xc9991a0904206da66891156e83170fef61a27c19
Block: 27189057
Paid: 0.0057312000152832 ETH (1910400 gas * 3.000000008 gwei)


Transactions saved to: broadcast/FakeNFT.s.sol/80001/run-latest.json



==========================

ONCHAIN EXECUTION COMPLETE & SUCCESSFUL. Transaction receipts written to "broadcast/FakeNFT.s.sol/80001/run-latest.json"

Transactions saved to: broadcast/FakeNFT.s.sol/80001/run-latest.json

 ~/workspace/knot/noxx-contract/ [main*] forge verify-contract --chain 80001 0xc9991a0904206da66891156e83170fef61a27c19 src/FakeNFT.sol:FakeNFT $SCAN_API_KEY

Submitting verification for [src/FakeNFT.sol:FakeNFT] 0xc9991a0904206da66891156e83170fef61a27c19.
Submitted contract for verification:
        Response: `OK`
        GUID: `dilelcvqvqvf55gmefxgwtpirxvrzgauawgjthcf6nguqpjked`
        URL: https://mumbai.polygonscan.com/address/0xc9991a0904206da66891156e83170fef61a27c19
```